### PR TITLE
Allow for overriding pipelines and private variable settings in the constructor arguments

### DIFF
--- a/lib/concourse.rb
+++ b/lib/concourse.rb
@@ -48,10 +48,15 @@ class Concourse
 
   def initialize project_name, args={}
     @project_name = project_name
+
+    @pipeline_erb_filename = args[:pipeline_erb_filename] || "#{project_name}.yml"
+    @pipeline_filename = args[:pipeline_filename] || @pipeline_erb_filename.sub(/.yml$/, '.final.yml')
+    @private_var_file = args[:private_var_file] || 'private.yml'
+
     @directory = args[:directory] || DEFAULT_DIRECTORY
-    @pipeline_filename = File.join(@directory, args[:pipeline_filename] || "#{project_name}.final.yml")
-    @pipeline_erb_filename = File.join(@directory, args[:pipeline_erb_filename] || "#{project_name}.yml")
-    @private_var_file = File.join(@directory, args[:private_var_file] || "private.yml")
+    @pipeline_erb_filename = File.join(@directory, @pipeline_erb_filename)
+    @pipeline_filename = File.join(@directory, @pipeline_filename)
+    @private_var_file = File.join(@directory, @private_var_file)
   end
 
   def erbify document_string, *args

--- a/lib/concourse.rb
+++ b/lib/concourse.rb
@@ -49,9 +49,9 @@ class Concourse
   def initialize project_name, args={}
     @project_name = project_name
     @directory = args[:directory] || DEFAULT_DIRECTORY
-    @pipeline_filename = File.join(@directory, "#{project_name}.final.yml")
-    @pipeline_erb_filename = File.join(@directory, "#{project_name}.yml")
-    @private_var_file = File.join(@directory, "private.yml")
+    @pipeline_filename = File.join(@directory, args[:pipeline_filename] || "#{project_name}.final.yml")
+    @pipeline_erb_filename = File.join(@directory, args[:pipeline_erb_filename] || "#{project_name}.yml")
+    @private_var_file = File.join(@directory, args[:private_var_file] || "private.yml")
   end
 
   def erbify document_string, *args

--- a/spec/concourse/rake_task_spec.rb
+++ b/spec/concourse/rake_task_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require 'securerandom'
 
 RSpec.describe Concourse do
   describe ".new" do
@@ -22,6 +23,30 @@ RSpec.describe Concourse do
 
       it "optionally accepts a directory name" do
         expect(Concourse.new("myproject", directory: "ci").directory).to eq "ci"
+      end
+    end
+
+    describe '#pipeline_filename' do
+      subject { instance.pipeline_filename }
+
+      let(:instance) { Concourse.new(project_name, args) }
+      let(:project_name) { 'myproject' }
+
+      context 'when no pipeline_filename is specified' do
+        let(:args) { {} }
+
+        it "defaults to use project_name" do
+          expect(subject).to eq "#{instance.directory}/#{project_name}.final.yml"
+        end
+      end
+
+      context 'when pipeline_filename is specified' do
+        let(:args) { {pipeline_filename: pipeline_filename} }
+        let(:pipeline_filename) { SecureRandom.hex(12) }
+
+        it 'uses the specified pipeline_filename' do
+          expect(subject).to eq "#{instance.directory}/#{pipeline_filename}"
+        end
       end
     end
   end

--- a/spec/concourse/rake_task_spec.rb
+++ b/spec/concourse/rake_task_spec.rb
@@ -48,6 +48,15 @@ RSpec.describe Concourse do
           expect(subject).to eq "#{instance.directory}/#{pipeline_filename}"
         end
       end
+
+      context 'when pipeline_erb_filename is specified' do
+        let(:args) { {pipeline_erb_filename: "#{pipeline_erb_filename}.yml"} }
+        let(:pipeline_erb_filename) { SecureRandom.hex(12) }
+
+        it 'derives the pipeline_filename from the pipeline_erb_filename' do
+          expect(subject).to eq "#{instance.directory}/#{pipeline_erb_filename}.final.yml"
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Our pipeline files do not necessarily match the defaults. It is helpful to allow us to override these defaults when constructing the concourse object.