### PR TITLE
Change fly target validation to instead use a default value which can selectivly be overridden

### DIFF
--- a/lib/concourse.rb
+++ b/lib/concourse.rb
@@ -15,7 +15,7 @@ class Concourse
 
   DEFAULT_DIRECTORY = "concourse"
 
-  attr_reader :project_name, :pipeline_filename, :pipeline_erb_filename, :directory, :private_var_file
+  attr_reader :project_name, :pipeline_filename, :pipeline_erb_filename, :directory, :private_var_file, :default_fly_target
 
   def self.url_for fly_target
     matching_line = `fly targets`.split("\n").grep(/^#{fly_target}/).first
@@ -45,6 +45,7 @@ class Concourse
     @pipeline_filename = File.join(@directory, "#{project_name}.final.yml")
     @pipeline_erb_filename = File.join(@directory, "#{project_name}.yml")
     @private_var_file = File.join(@directory, "private.yml")
+    @default_fly_target = args[:fly_target] || :default
   end
 
   def erbify document_string, *args
@@ -93,7 +94,7 @@ class Concourse
 
       desc "upload the pipeline file for #{project_name}"
       task "set", [:fly_target] => ["generate"] do |t, args|
-        fly_target = args[:fly_target] || :default
+        fly_target = args[:fly_target] || default_fly_target
         options = [
           "-p '#{project_name}'",
           "-c '#{pipeline_filename}'",
@@ -108,7 +109,7 @@ class Concourse
       %w[expose hide pause unpause destroy].each do |command|
         desc "#{command} the #{project_name} pipeline"
         task "#{command}", [:fly_target] do |t, args|
-          fly_target = args[:fly_target] || :default
+          fly_target = args[:fly_target] || default_fly_target
           sh "fly -t #{fly_target} #{command}-pipeline -p #{project_name}"
         end
       end
@@ -135,7 +136,7 @@ class Concourse
 
       desc "fly execute the specified task"
       task "task", [:fly_target, :job_task, :fly_execute_args] => "generate" do |t, args|
-        fly_target = args[:fly_target] || :default
+        fly_target = args[:fly_target] || default_fly_target
 
         job_task = args[:job_task]
         unless job_task
@@ -162,7 +163,7 @@ class Concourse
       #
       desc "abort all running builds for this pipeline"
       task "abort-builds", [:fly_target] do |t, args|
-        fly_target = args[:fly_target] || :default
+        fly_target = args[:fly_target] || default_fly_target
 
         `fly -t #{fly_target} builds`.split("\n").each do |line|
           pipeline_job, build_id, status = *line.split(/\s+/)[1,3]

--- a/lib/concourse.rb
+++ b/lib/concourse.rb
@@ -17,13 +17,6 @@ class Concourse
 
   attr_reader :project_name, :pipeline_filename, :pipeline_erb_filename, :directory, :private_var_file
 
-  def self.validate_fly_target task, task_args
-    unless task_args[:fly_target]
-      raise "ERROR: must specify a fly target, like `rake #{task.name}[targetname]`"
-    end
-    return task_args[:fly_target]
-  end
-
   def self.url_for fly_target
     matching_line = `fly targets`.split("\n").grep(/^#{fly_target}/).first
     raise "invalid fly target #{fly_target}" unless matching_line
@@ -100,7 +93,7 @@ class Concourse
 
       desc "upload the pipeline file for #{project_name}"
       task "set", [:fly_target] => ["generate"] do |t, args|
-        fly_target = Concourse.validate_fly_target t, args
+        fly_target = args[:fly_target] || :default
         options = [
           "-p '#{project_name}'",
           "-c '#{pipeline_filename}'",
@@ -115,7 +108,7 @@ class Concourse
       %w[expose hide pause unpause destroy].each do |command|
         desc "#{command} the #{project_name} pipeline"
         task "#{command}", [:fly_target] do |t, args|
-          fly_target = Concourse.validate_fly_target t, args
+          fly_target = args[:fly_target] || :default
           sh "fly -t #{fly_target} #{command}-pipeline -p #{project_name}"
         end
       end
@@ -142,7 +135,7 @@ class Concourse
 
       desc "fly execute the specified task"
       task "task", [:fly_target, :job_task, :fly_execute_args] => "generate" do |t, args|
-        fly_target = Concourse.validate_fly_target t, args
+        fly_target = args[:fly_target] || :default
 
         job_task = args[:job_task]
         unless job_task
@@ -169,7 +162,7 @@ class Concourse
       #
       desc "abort all running builds for this pipeline"
       task "abort-builds", [:fly_target] do |t, args|
-        fly_target = Concourse.validate_fly_target t, args
+        fly_target = args[:fly_target] || :default
 
         `fly -t #{fly_target} builds`.split("\n").each do |line|
           pipeline_job, build_id, status = *line.split(/\s+/)[1,3]


### PR DESCRIPTION
In our environment we only very rarely override the fly target when using this gem. It would save a lot of typing if the fly target could have a default that can be overridden when desired. I realize this creates an increased risk that the user may not be actively thinking about which concourse instance they are connecting to. For us, at least, this risk is mitigated by the rarity of needing to connect to alternate concourse servers.